### PR TITLE
gachadata-serverに求められる基本的な機能を実装する

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+export HTTP_PORT=8001
+export MYSQL_ADDRESS=localhost
+export MYSQL_PORT=3306
+export MYSQL_USER=root
+export MYSQL_PASSWORD=unchamaisgod

--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,0 @@
-export HTTP_PORT=8001
-export MYSQL_ADDRESS=localhost
-export MYSQL_PORT=3306
-export MYSQL_USER=root
-export MYSQL_PASSWORD=unchamaisgod

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 server/target
 .idea
+.envrc

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -190,6 +190,7 @@ name = "gachadata-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "envy",
  "serde",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -198,6 +198,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "bytes",
  "envy",
  "serde",
  "tokio",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -482,6 +482,20 @@ name = "serde"
 version = "1.0.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b88756493a5bd5e5395d53baa70b194b05764ab85b59e43e4b8f4e1192fa9b1"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.174"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e5c3a298c7f978e53536f95a63bdc4c4a64550582f31a0359a9afda6aede62e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -168,6 +168,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
 name = "futures-task"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +201,8 @@ dependencies = [
  "envy",
  "serde",
  "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -582,6 +590,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,7 +639,19 @@ dependencies = [
  "cfg-if",
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 anyhow = "1.0.72"
 async-trait = "0.1.72"
 axum = "0.6.19"
+bytes = "1.4.0"
 envy = "0.4.2"
 serde = { version = "1.0.174", features = ["derive"] }
 tokio = { version = "1.29.1", features = ["full"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -12,3 +12,5 @@ axum = "0.6.19"
 envy = "0.4.2"
 serde = "1.0.174"
 tokio = { version = "1.29.1", features = ["full"] }
+tokio-util = { version = "0.7.8", features = ["io"] }
+tracing = "0.1.37"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.72"
 async-trait = "0.1.72"
 axum = "0.6.19"
 envy = "0.4.2"
-serde = "1.0.174"
+serde = { version = "1.0.174", features = ["derive"] }
 tokio = { version = "1.29.1", features = ["full"] }
 tokio-util = { version = "0.7.8", features = ["io"] }
 tracing = "0.1.37"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.72"
+async-trait = "0.1.72"
 axum = "0.6.19"
 envy = "0.4.2"
 serde = "1.0.174"

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,5 +1,17 @@
 use anyhow::anyhow;
-use crate::config::Config;
+
+mod domain {
+    use std::fmt::Debug;
+    use std::fs::File;
+
+    pub struct GachadataDump(pub File);
+
+    #[async_trait::async_trait]
+    pub trait GachaDataRepository: Debug + Sync + Send + 'static {
+        async fn get_gachadata(&self) -> anyhow::Result<GachadataDump>;
+    }
+
+}
 
 mod config {
 
@@ -36,8 +48,10 @@ mod config {
 
 #[tokio::main]
 async fn main() {
+    use crate::config::Config;
+
     let config = Config::from_environment()
-        .map_err(anyhow!("Failed to load config from environment."))?;
+        .map_err(anyhow!("Failed to load config from environment variables."))?;
 
     let addr = std::net::SocketAddr::from(([0, 0, 0, 0], config.http_port.port));
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -68,6 +68,31 @@ mod infra_repository_impls {
 
 }
 
+mod presentation {
+    use axum::body::StreamBody;
+    use axum::extract::State;
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    use tokio_util::io::ReaderStream;
+    use crate::domain::GachaDataRepository;
+
+    pub async fn get_gachadata_handler(State(repository): &State<dyn GachaDataRepository>) -> impl IntoResponse {
+        match repository.get_gachadata().await {
+            Ok(gachadataDump) => {
+                let stream = ReaderStream::new(gachadataDump.0);
+                let body = StreamBody::new(stream);
+
+                (StatusCode::OK, body).into_response()
+            },
+            Err(err) => {
+                tracing::error!("{}", err);
+                (StatusCode::INTERNAL_SERVER_ERROR, "Failed to get gachadata.sql. Please contact to administrators.").into_response()
+            }
+        }
+    }
+
+}
+
 mod config {
 
     pub struct HttpPort {


### PR DESCRIPTION
とりあえずダンプファイルをダウンロードできるように。
ドキュメントやCI含めた整備は後々やります