### PR TITLE
fix: Dockerイメージビルドの失敗を修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # syntax=docker/dockerfile:1.25
-FROM lukemathwalker/cargo-chef:latest-rust-1.87 AS chef
+# NOTE: Rustのバージョンはrust-toolchain.tomlと合わせること (Renovateはこのタグ形式を追跡できない)。
+# また、実行ステージ (ubuntu:24.04, glibc 2.39) で動くバイナリにするため、
+# glibcがより古いbookworm variantを使う (デフォルトのtrixieはglibc 2.41)
+FROM lukemathwalker/cargo-chef:latest-rust-1.97.1-bookworm AS chef
 WORKDIR /app
 
 FROM chef AS planner
@@ -21,7 +24,7 @@ LABEL org.opencontainers.image.source=https://github.com/GiganticMinecraft/gacha
 RUN apt-get update -y && apt-get install -y curl
 
 RUN curl -LsSO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
-RUN echo "73f4ab14ccc3ceb8c03bb283dd131a3235cfc28086475f43e9291d2060d48c97 mariadb_repo_setup" \
+RUN echo "7325ac7755809ca3312b446bd832542421699298f25b701f9a111bb42df0c7c1 mariadb_repo_setup" \
         | sha256sum -c -
 RUN chmod +x mariadb_repo_setup
 RUN ./mariadb_repo_setup \


### PR DESCRIPTION
## 概要

mainブランチの「Build and release」ワークフローが2026-04-10以降すべて失敗していたのを修正します。

## 原因

1. **rustcバージョンの乖離**: Dockerfileのビルドイメージが `cargo-chef:latest-rust-1.87` に固定されたままだった一方、依存クレート (sentry 0.48.x、time 0.3.47など) がrustc 1.88以上を要求するようになり、`cargo chef cook` が失敗していました。`rust-toolchain.toml` はRenovateが1.97.1まで更新し続けていましたが、`latest-rust-1.87` というタグ形式はRenovateがバージョンとして解釈できないため、Dockerfile側だけ放置されて乖離していました (CheckCodeはrust-toolchain.tomlを使うため成功し続けていた)。
2. **mariadb_repo_setupのチェックサム失効**: MariaDB側がスクリプトを更新したため、固定していたsha256が一致しなくなっていました。これまではrustcエラーで先に落ちていたため隠れていた問題です。

## 修正内容

- cargo-chefイメージを `latest-rust-1.97.1-bookworm` に更新 (rust-toolchain.tomlと同期)
  - デフォルトタグはtrixieベース (glibc 2.41) になっており、実行ステージのubuntu:24.04 (glibc 2.39) でバイナリが動かなくなるため、bookworm variant (glibc 2.36) を明示指定しています
- mariadb_repo_setupのsha256を現行版 (script version 2026-06-30) に更新

## 検証

ローカル (arm64) でCIと同じ構成 (`docker build -f Dockerfile server/`) でビルドが成功することを確認済み:
- `cargo chef cook` / `cargo build --release` 通過
- mariadb-client 11.4.7 のインストール成功
- コンテナ内でバイナリが起動することを確認 (環境変数未設定のパニックまで到達 = glibcリンク問題なし)

## 補足

`latest-rust-X.Y.Z` 形式のタグはRenovateが追跡できないため、今後もrust-toolchain.tomlの更新に合わせて手動で更新する必要があります (Dockerfileにコメントで注記済み)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)