### PR TITLE
chore: dockerfile syntax directive をメジャーバージョン指定に揃える

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.25
+# syntax=docker/dockerfile:1
 # NOTE: Rustのバージョンはrust-toolchain.tomlと合わせること (Renovateはこのタグ形式を追跡できない)。
 # また、実行ステージ (ubuntu:24.04, glibc 2.39) で動くバイナリにするため、
 # glibcがより古いbookworm variantを使う (デフォルトのtrixieはglibc 2.41)


### PR DESCRIPTION
## 概要

`# syntax=docker/dockerfile:1.xx` のようにマイナーバージョンまで固定していた syntax directive を `docker/dockerfile:1` に変更します。

メジャーバージョンのみの指定にすることで、BuildKit が常に最新の 1.x 系 Dockerfile frontend を使うようになり、バージョン更新の追従が不要になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
